### PR TITLE
Update cibuildwheel to v3.4.1

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -40,15 +40,15 @@ jobs:
 
       - name: Build wheels Linux
         if: matrix.os == 'ubuntu-24.04'
-        uses: pypa/cibuildwheel@v3.0.0
+        uses: pypa/cibuildwheel@v3.4.1
 
       - name: Build wheels Mac
         if: matrix.os == 'macos-14'
-        uses: pypa/cibuildwheel@v3.0.0
+        uses: pypa/cibuildwheel@v3.4.1
 
       - name: Build wheels Windows
         if: matrix.os == 'windows-2025'
-        uses: pypa/cibuildwheel@v3.0.0
+        uses: pypa/cibuildwheel@v3.4.1
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/readme.html#installation-and-upgrade)
 
 ## 2.8.1.dev (development stage/unreleased/unstable)
+### Changed
+- build_wheels.yml: Upgraded `cibuildwheel` from `v3.0.0` to `v3.4.1`
 
 ## 2.8.1
 ### Added


### PR DESCRIPTION
## Summary
- Upgraded `cibuildwheel` from `v3.0.0` to `v3.4.1` in `build_wheels.yml`
- Updated `CHANGELOG.md`

## Test plan
- [ ] Trigger "Build and Publish GH+PyPi" workflow manually to verify wheels build successfully