### PR TITLE
Add support for exchange trbinance.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 2.8.1.dev (development stage/unreleased/unstable)
 ### Added
+- Added support for exchange `trbinance.com` (closes #13)
 - Added Python 3.14 support
 - Added mocked unit tests for `Cluster` class (cluster.py)
 ### Changed

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ The Python package [UNICORN Binance Local Depth Cache](https://github.com/oliver
 provides local order books for the Binance Exchanges 
 [Binance](https://github.com/binance-exchange/binance-official-api-docs) ([+Testnet](https://testnet.binance.vision/)), 
 [Binance Futures](https://binance-docs.github.io/apidocs/futures/en/#websocket-market-streams) 
-([+Testnet](https://testnet.binancefuture.com)) and [Binance US](https://www.binance.us/).
+([+Testnet](https://testnet.binancefuture.com)), [Binance US](https://www.binance.us/) and 
+[TRBinance](https://www.binance.tr/).
 
 ***The algorithm of the DepthCache management was designed according to these instructions:***
 
@@ -161,6 +162,7 @@ Since, according to Binance's predefined algorithm,
 - [Binance Spot: "How to manage a local order book correctly"](https://binance-docs.github.io/apidocs/spot/en/#how-to-manage-a-local-order-book-correctly)
 - [Binance Futures: "How to manage a local order book correctly"](https://binance-docs.github.io/apidocs/futures/en/#diff-book-depth-streams)
 - [Binance US: "Managing a Local Order Book"](https://docs.binance.us/#order-book-depth-diff-stream)
+- [TRBinance: "Diff. Depth Stream"](https://www.binance.tr/apidocs/#diff-depth-stream)
 
 With [create_depthcache()`](https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/unicorn_binance_local_depth_cache.html?highlight=create_depthcache#unicorn_binance_local_depth_cache.manager.BinanceLocalDepthCacheManager.create_depthcaches) 
 the DepthCache is started and initialized, i.e. for each DepthCache that is to be created, a separate 
@@ -198,6 +200,7 @@ is thrown or ask with [`is_depth_cache_synchronized()`](https://oliver-zehentlei
 | [Binance USD-M Futures](https://www.binance.com)                   | `binance.com-futures`         |
 | [Binance USD-M Futures Testnet](https://testnet.binancefuture.com) | `binance.com-futures-testnet` |
 | [Binance US](https://www.binance.us/)                              | `binance.us`                  |
+| [TRBinance](https://www.binance.tr/)                               | `trbinance.com`               |
 
 - Create multiple depth caches within a single object instance. 
 

--- a/unicorn_binance_local_depth_cache/manager.py
+++ b/unicorn_binance_local_depth_cache/manager.py
@@ -69,8 +69,8 @@ class BinanceLocalDepthCacheManager(threading.Thread):
         - https://binance-docs.github.io/apidocs/spot/en/#how-to-manage-a-local-order-book-correctly
         - https://binance-docs.github.io/apidocs/futures/en/#diff-book-depth-streams
 
-    :param exchange: Select binance.com, binance.com-testnet, binance.com-futures, binance.com-futures-testnet
-                     (default: binance.com)
+    :param exchange: Select binance.com, binance.com-testnet, binance.com-futures, binance.com-futures-testnet,
+                     binance.us, trbinance.com (default: binance.com)
     :type exchange: str
     :param default_refresh_interval: The default refresh interval in seconds, default is None. The DepthCache is reset
                                      and reinitialized at this interval.
@@ -393,7 +393,8 @@ class BinanceLocalDepthCacheManager(threading.Thread):
         try:
             if self.exchange == "binance.com" \
                     or self.exchange == "binance.com-testnet" \
-                    or self.exchange == "binance.us":
+                    or self.exchange == "binance.us" \
+                    or self.exchange == "trbinance.com":
                 order_book = self.ubra.get_order_book(symbol=market.upper(), limit=1000)
             elif self.exchange == "binance.com-futures" or self.exchange == "binance.com-futures-testnet":
                 order_book = self.ubra.futures_order_book(symbol=market.upper(), limit=1000)
@@ -586,7 +587,8 @@ class BinanceLocalDepthCacheManager(threading.Thread):
                 # Gap detection
                 if self.exchange == "binance.com" \
                         or self.exchange == "binance.com-testnet" \
-                        or self.exchange == "binance.us":
+                        or self.exchange == "binance.us" \
+                        or self.exchange == "trbinance.com":
                     if stream_data['data']['U'] != self.depth_caches[market]['last_update_id']+1:
                         logger.error(f"BinanceLocalDepthCacheManager._manage_depth_cache_async(stream_id={stream_id}) "
                                      f"- There is a gap between the last and the penultimate update ID, the depth_cache"
@@ -631,7 +633,8 @@ class BinanceLocalDepthCacheManager(threading.Thread):
                     continue
                 if self.exchange == "binance.com" \
                         or self.exchange == "binance.com-testnet" \
-                        or self.exchange == "binance.us":
+                        or self.exchange == "binance.us" \
+                        or self.exchange == "trbinance.com":
                     if int(stream_data['data']['u']) <= self.depth_caches[market]['last_update_id']:
                         # Drop it
                         logger.debug(f"BinanceLocalDepthCacheManager._manage_depth_cache_async(stream_id={stream_id}) "


### PR DESCRIPTION
## Summary

Closes #13

Adds `trbinance.com` support to UBLDC. TRBinance uses the same diff depth stream algorithm and REST snapshot endpoint as Binance Spot / Binance US — verified against the official docs at https://www.binance.tr/apidocs/.

**Changes in `manager.py`:**
- `_get_order_book_from_rest()`: add `trbinance.com` to the Spot branch → uses `get_order_book(limit=1000)`
- `_manage_depth_cache_async()` gap detection: add `trbinance.com` to the Spot branch → checks `U == last_u+1`
- `_manage_depth_cache_async()` init logic: add `trbinance.com` to the Spot branch → condition `U <= lastUpdateId+1 <= u`
- Docstring: exchange parameter list updated

**Changes in `README.md`:**
- Exchange table: added TRBinance row with `trbinance.com` string
- Description: added TRBinance to supported exchanges
- Algorithm references: added link to TRBinance diff depth stream docs

**Changes in `CHANGELOG.md`:**
- Added entry under `2.8.1.dev`