### PR TITLE
Fix: replace print() with logger in Cluster request methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 - Added Python 3.14 support
 - Added mocked unit tests for `Cluster` class (cluster.py)
+### Fixed
+- cluster.py: replaced `print()` with proper `logger` calls in `_request()` and `_request_async()` — `error` for network/client failures, `warning` for timeouts and cancellations
 ### Changed
 - build_wheels.yml: Upgraded `cibuildwheel` from `v3.0.0` to `v3.4.1`
 - setup.py: Fixed author from "LUCIT Systems and Development" to "Oliver Zehentleitner"

--- a/unicorn_binance_local_depth_cache/cluster.py
+++ b/unicorn_binance_local_depth_cache/cluster.py
@@ -101,7 +101,7 @@ class Cluster:
                 result['debug']['transmission_time'] = request_time - result['debug']['cluster_execution_time']
             return result
         except requests.exceptions.RequestException as error_msg:
-            print(f"An error occurred: {error_msg}")
+            logger.error(f"Cluster._request() - {self.url+endpoint} - {error_msg}")
             return {"error": error_msg}
 
     async def _request_async(self,
@@ -141,13 +141,13 @@ class Cluster:
                     request_time - result['debug']['cluster_execution_time']
             return result
         except asyncio.CancelledError as error_msg:
-            print(f"An error occurred: asyncio.CancelledError - {self.url+endpoint} - {error_msg}")
+            logger.warning(f"Cluster._request_async() - asyncio.CancelledError - {self.url+endpoint} - {error_msg}")
             return {"error": f"asyncio.CancelledError - {self.url+endpoint} - {str(error_msg)}"}
         except asyncio.TimeoutError:
-            print(f"An error occurred: asyncio.TimeoutError - {self.url+endpoint}")
+            logger.warning(f"Cluster._request_async() - asyncio.TimeoutError - {self.url+endpoint}")
             return {"error": f"asyncio.TimeoutError - {self.url+endpoint}"}
         except aiohttp.ClientError as error_msg:
-            print(f"An error occurred: aiohttp.ClientError- {self.url+endpoint} - {error_msg}")
+            logger.error(f"Cluster._request_async() - aiohttp.ClientError - {self.url+endpoint} - {error_msg}")
             return {"error": f"aiohttp.ClientError - {self.url+endpoint} - {str(error_msg)}"}
 
     def create_depthcache(self,


### PR DESCRIPTION
## Summary

`cluster.py` used bare `print()` for error handling in `_request()` and `_request_async()`, despite `logger` already being imported and used elsewhere in the file. This caused test output noise (visible in CI) and bypassed the standard logging infrastructure.

**Log level choices:**
- `requests.exceptions.RequestException` → `logger.error()` — cluster unreachable, real operational failure
- `aiohttp.ClientError` → `logger.error()` — same, async variant
- `asyncio.TimeoutError` → `logger.warning()` — transient, retryable
- `asyncio.CancelledError` → `logger.warning()` — often intentional (e.g. shutdown)

Also adds method name and URL to each log message for easier debugging.