### PR TITLE
Add get_last_update_time(market) method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 2.8.1.dev (development stage/unreleased/unstable)
 ### Added
+- Added `get_last_update_time(market)` — returns Unix timestamp in milliseconds of the last processed depth update, or `None` if not yet synced (closes #35)
 - Added support for exchange `trbinance.com` (closes #13)
 - Added Python 3.14 support
 - Added mocked unit tests for `Cluster` class (cluster.py)

--- a/unicorn_binance_local_depth_cache/manager.py
+++ b/unicorn_binance_local_depth_cache/manager.py
@@ -479,7 +479,7 @@ class BinanceLocalDepthCacheManager(threading.Thread):
             return False
         self._reset_depth_cache(market=market)
         self.depth_caches[market]['last_refresh_time'] = int(time.time())
-        self.depth_caches[market]['last_update_time'] = int(time.time())
+        self.depth_caches[market]['last_update_time'] = int(time.time() * 1000)
         try:
             self.depth_caches[market]['last_update_id'] = int(order_book['lastUpdateId'])
         except TypeError as error_msg:
@@ -619,7 +619,7 @@ class BinanceLocalDepthCacheManager(threading.Thread):
                              f"{stream_data['data']['U']} - {stream_data['data']['u']}")
                 self._apply_updates(asks=stream_data['data']['a'], bids=stream_data['data']['b'], market=market)
                 self.depth_caches[market]['last_update_id'] = int(stream_data['data']['u'])
-                self.depth_caches[market]['last_update_time'] = int(time.time())
+                self.depth_caches[market]['last_update_time'] = int(time.time() * 1000)
                 self.ubwa.asyncio_queue_task_done(stream_id=stream_id)
                 continue
             else:
@@ -651,7 +651,7 @@ class BinanceLocalDepthCacheManager(threading.Thread):
                         # Init (refresh) finished
                         last_sync_time = time.time()
                         self.depth_caches[market]['last_update_id'] = int(stream_data['data']['u'])
-                        self.depth_caches[market]['last_update_time'] = int(last_sync_time)
+                        self.depth_caches[market]['last_update_time'] = int(last_sync_time * 1000)
                         self.depth_caches[market]['last_refresh_time'] = int(last_sync_time)
                         self.depth_caches[market]['is_synchronized'] = True
                         self.ubwa.asyncio_queue_task_done(stream_id=stream_id)
@@ -673,7 +673,7 @@ class BinanceLocalDepthCacheManager(threading.Thread):
                         # Init (refresh) finished
                         last_sync_time = time.time()
                         self.depth_caches[market]['last_update_id'] = int(stream_data['data']['u'])
-                        self.depth_caches[market]['last_update_time'] = int(last_sync_time)
+                        self.depth_caches[market]['last_update_time'] = int(last_sync_time * 1000)
                         self.depth_caches[market]['is_synchronized'] = True
                         self.ubwa.asyncio_queue_task_done(stream_id=stream_id)
                         continue
@@ -956,13 +956,13 @@ class BinanceLocalDepthCacheManager(threading.Thread):
 
     def get_last_update_time(self, market: str = None) -> Optional[int]:
         """
-        Get the Unix timestamp of the last processed depth update for a market.
+        Get the Unix timestamp in milliseconds of the last processed depth update for a market.
 
         Returns ``None`` if the DepthCache exists but has not yet received its first update.
 
         :param market: Specify the market symbol for the used DepthCache
         :type market: str
-        :return: Unix timestamp (int) or None
+        :return: Unix timestamp in milliseconds (int) or None
         :raises DepthCacheNotFound: if the market is unknown
         """
         if market is None:

--- a/unicorn_binance_local_depth_cache/manager.py
+++ b/unicorn_binance_local_depth_cache/manager.py
@@ -954,6 +954,28 @@ class BinanceLocalDepthCacheManager(threading.Thread):
         except KeyError:
             raise DepthCacheNotFound(market=market)
 
+    def get_last_update_time(self, market: str = None) -> Optional[int]:
+        """
+        Get the Unix timestamp of the last processed depth update for a market.
+
+        Returns ``None`` if the DepthCache exists but has not yet received its first update.
+
+        :param market: Specify the market symbol for the used DepthCache
+        :type market: str
+        :return: Unix timestamp (int) or None
+        :raises DepthCacheNotFound: if the market is unknown
+        """
+        if market is None:
+            raise DepthCacheNotFound(market=market)
+        market = market.lower()
+        try:
+            last_update_time = self.depth_caches[market].get('last_update_time')
+        except KeyError:
+            raise DepthCacheNotFound(market=market)
+        logger.debug(f"BinanceLocalDepthCacheManager.get_last_update_time(market={market}) - "
+                     f"Returning: {last_update_time}")
+        return last_update_time
+
     def _get_book_side(self,
                        market: str = None,
                        limit_count: int = None,

--- a/unittest_binance_local_depth_cache.py
+++ b/unittest_binance_local_depth_cache.py
@@ -645,6 +645,18 @@ class TestUbldc(unittest.TestCase):
         with self.assertRaises(DepthCacheNotFound):
             self.__class__.ubldc.get_bids()
 
+    def test_get_last_update_time(self):
+        result = self.__class__.ubldc.get_last_update_time(market='BTCUSDT')
+        self.assertTrue(result is None or isinstance(result, int))
+
+    def test_invalid_market_get_last_update_time(self):
+        with self.assertRaises(DepthCacheNotFound):
+            self.__class__.ubldc.get_last_update_time(market='TEST_INVALID_MARKET')
+
+    def test_invalid_market_get_last_update_time_without_params(self):
+        with self.assertRaises(DepthCacheNotFound):
+            self.__class__.ubldc.get_last_update_time()
+
     def test_get_asks_threshold_volume(self):
         try:
             self.__class__.ubldc.get_asks(market='BTCUSDT', threshold_volume=200000)


### PR DESCRIPTION
## Summary

Closes #35

Adds `get_last_update_time(market: str) -> Optional[int]` to `BinanceLocalDepthCacheManager`.

**Behavior:**
- Returns Unix timestamp (`int`) of the last processed depth update for the given market
- Returns `None` if the DepthCache exists but has not yet received its first update (initial state before sync)
- Raises `DepthCacheNotFound` for unknown markets or missing `market` parameter

**Placement:** directly after `get_bids()`, consistent with existing `get_*` API style.

**Tests added:**
- `test_get_last_update_time` — valid market, accepts `int` or `None`
- `test_invalid_market_get_last_update_time` — unknown market raises `DepthCacheNotFound`
- `test_invalid_market_get_last_update_time_without_params` — no params raises `DepthCacheNotFound`