### PR TITLE
Docs: document TRBinance API key requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Added Python 3.14 support
 - Added mocked unit tests for `Cluster` class (cluster.py)
 ### Fixed
+- manager.py: detect REST API error responses in `_get_order_book_from_rest()` and log clearly instead of failing silently with a `KeyError` — includes hint for `trbinance.com` about required API key
 - cluster.py: replaced `print()` with proper `logger` calls in `_request()` and `_request_async()` — `error` for network/client failures, `warning` for timeouts and cancellations
 ### Changed
 - build_wheels.yml: Upgraded `cibuildwheel` from `v3.0.0` to `v3.4.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## 2.8.1.dev (development stage/unreleased/unstable)
 ### Added
 - Added `get_last_update_time(market)` — returns Unix timestamp in milliseconds of the last processed depth update, or `None` if not yet synced (closes #35)
-- Added support for exchange `trbinance.com` (closes #13)
+- Added support for exchange `trbinance.com` (closes #13) — note: TRBinance requires an API key even for public REST endpoints; pass `api_key`/`api_secret` to `BinanceRestApiManager`
 - Added Python 3.14 support
 - Added mocked unit tests for `Cluster` class (cluster.py)
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -200,7 +200,10 @@ is thrown or ask with [`is_depth_cache_synchronized()`](https://oliver-zehentlei
 | [Binance USD-M Futures](https://www.binance.com)                   | `binance.com-futures`         |
 | [Binance USD-M Futures Testnet](https://testnet.binancefuture.com) | `binance.com-futures-testnet` |
 | [Binance US](https://www.binance.us/)                              | `binance.us`                  |
-| [TRBinance](https://www.binance.tr/)                               | `trbinance.com`               |
+| [TRBinance](https://www.binance.tr/)                               | `trbinance.com` ¹             |
+
+  ¹ TRBinance requires an API key even for public REST endpoints (e.g. order book snapshots). 
+  Pass `api_key` and `api_secret` to `BinanceRestApiManager` when using `exchange="trbinance.com"`.
 
 - Create multiple depth caches within a single object instance. 
 

--- a/unicorn_binance_local_depth_cache/manager.py
+++ b/unicorn_binance_local_depth_cache/manager.py
@@ -420,6 +420,12 @@ class BinanceLocalDepthCacheManager(threading.Thread):
                          f"snapshot for the depth_cache with market {market} - requests.exceptions.ReadTimeout - "
                          f"error_msg: {error_msg}")
             return None
+        if 'lastUpdateId' not in order_book:
+            hint = (" - Note: TRBinance requires api_key/api_secret even for public REST endpoints"
+                    if self.exchange == "trbinance.com" else "")
+            logger.error(f"BinanceLocalDepthCacheManager._get_order_book_from_rest() - Received error response "
+                         f"instead of order_book for market {market}: {order_book}{hint}")
+            return None
         logger.debug(f"BinanceLocalDepthCacheManager._init_depth_get_order_book_from_rest_cache() - Downloaded "
                      f"order_book snapshot for the depth_cache with market {market}")
         return order_book


### PR DESCRIPTION
## Summary

TRBinance requires an API key even for public REST endpoints (e.g. `/api/v3/depth` for order book snapshots). Without `api_key`/`api_secret`, the REST snapshot will fail with error code 3701 and the DepthCache cannot initialize.

Added a footnote to the exchange table in `README.md` and a note in `CHANGELOG.md`.