### PR TITLE
Switch cluster.py from stdlib json to orjson

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - lucit::unicorn-binance-rest-api >=2.9.0
     - lucit::unicorn-binance-websocket-api >=2.10.2
     - Cython
+    - orjson
     - requests >=2.31.0
   run:
     - python
@@ -38,6 +39,7 @@ requirements:
     - lucit::unicorn-binance-websocket-api >=2.10.2
     - aiohttp
     - Cython
+    - orjson
     - requests >=2.31.0
 
 dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-local-dept
 python = ">=3.9.0"
 aiohttp = "*"
 Cython = "*"
+orjson = "*"
 requests = ">=2.31.0"
 unicorn-binance-rest-api = ">=2.9.0"
 unicorn-binance-websocket-api = ">=2.10.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@
 
 aiohttp
 Cython>=3.0.10
+orjson
 requests>=2.32.3
 unicorn-binance-rest-api>=2.8.1
 unicorn-binance-websocket-api>=2.10.2

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
      long_description=long_description,
      long_description_content_type="text/markdown",
      license='MIT',
-     install_requires=['aiohttp', 'Cython>=3.0.10', 'requests>=2.32.3',
+     install_requires=['aiohttp', 'Cython>=3.0.10', 'orjson', 'requests>=2.32.3',
                        'unicorn-binance-websocket-api>=2.10.2', 'unicorn-binance-rest-api>=2.9.0'],
      keywords='binance, depth cache',
      project_urls={

--- a/unicorn_binance_local_depth_cache/cluster.py
+++ b/unicorn_binance_local_depth_cache/cluster.py
@@ -41,7 +41,7 @@
 import aiohttp
 import asyncio
 import logging
-import json
+import orjson as json
 import requests
 import time
 from .cluster_endpoints import ClusterEndpoints


### PR DESCRIPTION
## Summary
- Replace `import json` with `import orjson as json` in cluster.py (suite-wide standard)
- Add orjson dependency to setup.py, pyproject.toml, requirements.txt, meta.yaml