### PR TITLE
Fix double JSON serialization in cluster POST requests

### DIFF
--- a/unicorn_binance_local_depth_cache/cluster.py
+++ b/unicorn_binance_local_depth_cache/cluster.py
@@ -88,8 +88,7 @@ class Cluster:
             if method == "get":
                 response = requests.get(self.url+endpoint, params=params, headers=headers, timeout=timeout)
             elif method == "post":
-                response = requests.post(self.url+endpoint, json=json.dumps(params),
-                                         headers={"Content-Type": "application/json"})
+                response = requests.post(self.url+endpoint, json=params)
             else:
                 raise ValueError("Allowed 'method' values: get, post")
             response.raise_for_status()


### PR DESCRIPTION
## Summary
`requests.post(json=json.dumps(params))` double-serializes: `json=` already calls `json.dumps()` internally. The server receives a JSON string instead of a JSON object, causing `body.get()` to fail with a 500.

Fix: `requests.post(json=params)` — let requests handle serialization.