### PR TITLE
Pin UBRA dependency to >=2.9.1 (latest released)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python>=3.8
   - aiohttp
-  - lucit::unicorn-binance-rest-api>=2.8.1
+  - lucit::unicorn-binance-rest-api>=2.9.1
   - lucit::unicorn-binance-websocket-api>=2.10.2
   - cython>=3.0.10
   - requests>=2.31.0

--- a/meta.yaml
+++ b/meta.yaml
@@ -28,14 +28,14 @@ requirements:
     - pip
     - mypy
     - aiohttp
-    - lucit::unicorn-binance-rest-api >=2.11.0
+    - lucit::unicorn-binance-rest-api >=2.9.1
     - lucit::unicorn-binance-websocket-api >=2.10.2
     - Cython
     - orjson
     - requests >=2.31.0
   run:
     - python
-    - lucit::unicorn-binance-rest-api >=2.11.0
+    - lucit::unicorn-binance-rest-api >=2.9.1
     - lucit::unicorn-binance-websocket-api >=2.10.2
     - aiohttp
     - Cython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ aiohttp = "*"
 Cython = "*"
 orjson = "*"
 requests = ">=2.31.0"
-unicorn-binance-rest-api = ">=2.11.0"
+unicorn-binance-rest-api = ">=2.9.1"
 unicorn-binance-websocket-api = ">=2.10.2"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ aiohttp
 Cython>=3.0.10
 orjson
 requests>=2.32.3
-unicorn-binance-rest-api>=2.8.1
+unicorn-binance-rest-api>=2.9.1
 unicorn-binance-websocket-api>=2.10.2

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
      long_description_content_type="text/markdown",
      license='MIT',
      install_requires=['aiohttp', 'Cython>=3.0.10', 'orjson', 'requests>=2.32.3',
-                       'unicorn-binance-websocket-api>=2.10.2', 'unicorn-binance-rest-api>=2.11.0'],
+                       'unicorn-binance-websocket-api>=2.10.2', 'unicorn-binance-rest-api>=2.9.1'],
      keywords='binance, depth cache',
      project_urls={
          'Documentation': 'https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache',


### PR DESCRIPTION
## Summary
The 2.10.0 and 2.11.0 dev bumps lifted the \`unicorn-binance-rest-api\` constraint along with the UBLDC version, but **no UBRA 2.10 / 2.11 was ever released** — current PyPI head is 2.9.1.

Effect: fresh \`pip install unicorn-binance-local-depth-cache\` falls through pip's resolver, downgrades, and silently leaves the user on an outdated UBLDC (or fails completely on a clean env). Hit this in person while debugging the UBDCC DCN-death symptom — Oliver's venv stayed pinned to UBLDC 2.9.0 for exactly this reason, which then caused \`TypeError: __init__() got an unexpected keyword argument 'on_restart'\` in UBDCC.

UBLDC source only uses the long-stable UBRA API (\`BinanceRestApiManager(exchange=...)\`, \`get_order_book\`, …), so the lower bound is safe.

Synced all five places: \`setup.py\`, \`pyproject.toml\`, \`requirements.txt\`, \`environment.yml\`, \`meta.yaml\`.

## Test plan
- [ ] \`pip install -U unicorn-binance-local-depth-cache\` in a clean venv after release → resolves to 2.11.0
- [ ] UBDCC 0.4.0 then runs without the \`on_restart\` TypeError