### PR TITLE
Sync UBWA pin to >=2.11.0 in requirements.txt and environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,6 @@ dependencies:
   - python>=3.8
   - aiohttp
   - lucit::unicorn-binance-rest-api>=2.9.1
-  - lucit::unicorn-binance-websocket-api>=2.10.2
+  - lucit::unicorn-binance-websocket-api>=2.11.0
   - cython>=3.0.10
   - requests>=2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ Cython>=3.0.10
 orjson
 requests>=2.32.3
 unicorn-binance-rest-api>=2.9.1
-unicorn-binance-websocket-api>=2.10.2
+unicorn-binance-websocket-api>=2.11.0


### PR DESCRIPTION
## Summary
`setup.py`, `pyproject.toml` and `meta.yaml` already declared `unicorn-binance-websocket-api>=2.11.0`; `requirements.txt` and `environment.yml` were still at `>=2.10.2`. Bring all five files in sync.

## Test plan
- [ ] CI install passes