### PR TITLE
Fix wheel artifacts not published to PyPI since 2.8.1

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -85,7 +85,6 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: artifact
           path: dist
 
       - name: Move all artifacts into dist_upload/


### PR DESCRIPTION
## Summary
- Remove explicit `name: artifact` from `download-artifact` step in `build_wheels.yml`
- The upload step names artifacts `artifact-${{ matrix.os }}` (e.g. `artifact-ubuntu-24.04`), but the download step looked for `artifact` which doesn't exist — causing a silent failure
- As a result, only the sdist was published to PyPI since version 2.8.1 (July 2025), no compiled wheels
- Fix aligns with how UBWA handles it: omit `name` so `download-artifact@v4` fetches all artifacts

## Test plan
- [ ] Merge and run the `Build and Publish GH+PyPi` workflow
- [ ] Verify wheels appear on PyPI alongside the sdist