### PR TITLE
Remove LUCIT references from examples, add clickable UBLDC/UBDCC links

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,4 +5,4 @@ For each example you will find a `README.md` and a `requirements.txt` to install
 file is to download and start, if an example does not work, we are happy about a 
 [patch](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/fork) or a message via 
 [GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/issues/new/choose) or 
-[our chat](https://www.lucit.tech/get-support.html).
+[Telegram community](https://t.me/unicorndevs).

--- a/examples/binance_depthcache_limit_count/README.md
+++ b/examples/binance_depthcache_limit_count/README.md
@@ -10,9 +10,6 @@ Before running the provided script, install the required Python packages:
 pip install -r requirements.txt
 ```
 
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
@@ -27,5 +24,6 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache).
+For further assistance or to report issues, please open a 
+[GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/issues/new/choose) 
+or join the [UNICORN Binance Suite community on Telegram](https://t.me/unicorndevs).

--- a/examples/binance_depthcache_multi_markets/README.md
+++ b/examples/binance_depthcache_multi_markets/README.md
@@ -10,9 +10,6 @@ Before running the provided script, install the required Python packages:
 pip install -r requirements.txt
 ```
 
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
@@ -27,5 +24,6 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache).
+For further assistance or to report issues, please open a 
+[GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/issues/new/choose) 
+or join the [UNICORN Binance Suite community on Telegram](https://t.me/unicorndevs).

--- a/examples/binance_depthcache_threshold_volume/README.md
+++ b/examples/binance_depthcache_threshold_volume/README.md
@@ -11,9 +11,6 @@ Before running the provided script, install the required Python packages:
 pip install -r requirements.txt
 ```
 
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
@@ -28,5 +25,6 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache).
+For further assistance or to report issues, please open a 
+[GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/issues/new/choose) 
+or join the [UNICORN Binance Suite community on Telegram](https://t.me/unicorndevs).

--- a/examples/binance_futures_depthcache/README.md
+++ b/examples/binance_futures_depthcache/README.md
@@ -10,9 +10,6 @@ Before running the provided script, install the required Python packages:
 pip install -r requirements.txt
 ```
 
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
@@ -27,5 +24,6 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache).
+For further assistance or to report issues, please open a 
+[GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/issues/new/choose) 
+or join the [UNICORN Binance Suite community on Telegram](https://t.me/unicorndevs).

--- a/examples/binance_us_depthcache/README.md
+++ b/examples/binance_us_depthcache/README.md
@@ -10,9 +10,6 @@ Before running the provided script, install the required Python packages:
 pip install -r requirements.txt
 ```
 
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
@@ -27,5 +24,6 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache).
+For further assistance or to report issues, please open a 
+[GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/issues/new/choose) 
+or join the [UNICORN Binance Suite community on Telegram](https://t.me/unicorndevs).

--- a/examples/ubldc-demo/README.md
+++ b/examples/ubldc-demo/README.md
@@ -1,6 +1,7 @@
-# UBLDC Demo
+# [UBLDC](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache) Demo
 ## Overview
-This is the original script from https://ubldc-demo.lucit.tech
+A demo script showing [UBLDC](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache) in action 
+with multiple DepthCaches, limit_count and threshold_volume filtering.
 
 ## Prerequisites
 Ensure you have Python 3.7+ installed on your system. 
@@ -10,13 +11,10 @@ Before running the provided script, install the required Python packages:
 pip install -r requirements.txt
 ```
 
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
-python ubdcc-demo.py
+python ubldc-demo.py
 ```
 
 ### Graceful Shutdown:
@@ -27,5 +25,6 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache).
+For further assistance or to report issues, please open a 
+[GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/issues/new/choose) 
+or join the [UNICORN Binance Suite community on Telegram](https://t.me/unicorndevs).

--- a/examples/ubldc-demo/ubldc-demo.py
+++ b/examples/ubldc-demo/ubldc-demo.py
@@ -9,7 +9,7 @@ import logging
 import os
 
 amount_test_caches: int = 5
-footer: str = "By LUCIT - www.lucit.tech"
+footer: str = "UNICORN Binance Suite - github.com/oliver-zehentleitner"
 exchange: str = "binance.com-futures"
 limit_count: int = 2
 title: str = "UBLDC Demo"

--- a/examples/ubldc_package_update_check/README.md
+++ b/examples/ubldc_package_update_check/README.md
@@ -10,14 +10,12 @@ Before running the provided script, install the required Python packages:
 pip install -r requirements.txt
 ```
 
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
 python ubldc_package_update_check.py
 ```
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache).
+For further assistance or to report issues, please open a 
+[GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/issues/new/choose) 
+or join the [UNICORN Binance Suite community on Telegram](https://t.me/unicorndevs).

--- a/examples/unicorn_binance_depth_cache_cluster/README.md
+++ b/examples/unicorn_binance_depth_cache_cluster/README.md
@@ -1,11 +1,13 @@
 # UNICORN DepthCache Cluster for Binance
-A highly scalable Kubernetes application from LUCIT to manage multiple and redundant UNICORN Binance Local Depth Cache 
-Instances on a Kubernetes Cluster for high-frequency access to Binance's DepthCache data (order books). 
-
-[UNICORN DepthCache Cluster for Binance](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)
+Examples for using [UBLDC](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache)'s built-in 
+cluster interface to connect to a 
+[UNICORN Binance DepthCache Cluster (UBDCC)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster).
 
 ## Overview
-Instead of creating and using local DepthCaches, we connect to a UNICORN DepthCache Cluster for Binance.
+Instead of creating and using local DepthCaches, we connect to a 
+[UBDCC](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) cluster and use 
+[UBLDC](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache)'s `cluster` module for 
+synchronous and asynchronous access to shared order book data.
 
 ## Prerequisites
 Ensure you have Python 3.7+ installed on your system. 
@@ -15,15 +17,12 @@ Before running the provided script, install the required Python packages:
 pip install -r requirements.txt
 ```
 
-And set up your `.env` file!
-
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
+And set up your `.env` file with `UBDCC_ADDRESS` and `UBDCC_PORT`.
 
 ## Usage
 ### Running the Script:
 ```bash
-python xxx.py
+python <script_name>.py
 ```
 
 ### Graceful Shutdown:
@@ -34,5 +33,6 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache).
+For further assistance or to report issues, please open a 
+[GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/issues/new/choose) 
+or join the [UNICORN Binance Suite community on Telegram](https://t.me/unicorndevs).


### PR DESCRIPTION
## Summary
- Remove all remaining LUCIT references from example READMEs (license sections, support links, demo URL, footer)
- Replace LUCIT support links with GitHub Issues + Telegram community links
- Rewrite cluster examples README with clickable [UBLDC](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache) and [UBDCC](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) links, describe cluster interface
- Update `ubldc-demo.py` footer

## Files changed (10)
- `examples/README.md` — LUCIT chat → Telegram
- `examples/unicorn_binance_depth_cache_cluster/README.md` — full rewrite
- `examples/ubldc-demo/README.md` — remove LUCIT demo URL, add description, UBLDC clickable
- `examples/ubldc-demo/ubldc-demo.py` — footer update
- 6 other example READMEs — remove license section, update support links

## Test plan
- [ ] Verify all links resolve correctly on GitHub
- [ ] Confirm no LUCIT references remain in `examples/`