### PR TITLE
Add European Options depth cache example

### DIFF
--- a/examples/binance_options_depthcache/README.md
+++ b/examples/binance_options_depthcache/README.md
@@ -1,0 +1,34 @@
+# Binance Options DepthCache
+## Overview
+Create local order book DepthCaches for Binance European Options (Vanilla Options) 
+with `exchange="binance.com-vanilla-options"`.
+
+Options symbols use the format `UNDERLYING-YYMMDD-STRIKE-C/P`, e.g. `BTC-260626-120000-C`.
+
+## Prerequisites
+Ensure you have Python 3.9+ installed on your system.
+
+Before running the provided script, install the required Python packages:
+```bash
+pip install -r requirements.txt
+```
+
+No API key is needed for public market data.
+
+## Usage
+### Running the Script:
+```bash
+python binance_options_depthcache.py
+```
+
+### Graceful Shutdown:
+The script is designed to handle a graceful shutdown upon receiving a KeyboardInterrupt (e.g., Ctrl+C) or encountering 
+an unexpected exception.
+
+## Logging
+The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
+file named after the script with a .log extension.
+
+For further assistance or to report issues, please open a 
+[GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/issues/new/choose) 
+or join the [UNICORN Binance Suite community on Telegram](https://t.me/unicorndevs).

--- a/examples/binance_options_depthcache/binance_options_depthcache.py
+++ b/examples/binance_options_depthcache/binance_options_depthcache.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ¯\_(ツ)_/¯
+
+from unicorn_binance_local_depth_cache import BinanceLocalDepthCacheManager, DepthCacheOutOfSync
+import asyncio
+import logging
+import os
+
+# Options symbols use the format: UNDERLYING-YYMMDD-STRIKE-C/P
+# Adjust these to currently listed options on Binance
+markets = ["BTC-260626-120000-C", "BTC-260626-120000-P"]
+exchange = "binance.com-vanilla-options"
+limit_count = 5
+
+logging.getLogger("unicorn_binance_local_depth_cache")
+logging.basicConfig(level=logging.DEBUG,
+                    filename=os.path.basename(__file__) + '.log',
+                    format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
+                    style="{")
+
+
+async def main():
+    print(f"Starting {exchange} DepthCaches for {len(markets)} markets: {markets}")
+    ubldc.create_depthcache(markets=markets)
+
+    while ubldc.is_stop_request() is False:
+        for market in markets:
+            try:
+                top_asks = ubldc.get_asks(market=market, limit_count=limit_count)
+                top_bids = ubldc.get_bids(market=market, limit_count=limit_count)
+            except DepthCacheOutOfSync:
+                top_asks = "Out of sync!"
+                top_bids = "Out of sync!"
+            print(f"[{market}] synced={ubldc.is_depth_cache_synchronized(market=market)}")
+            print(f"  asks: {top_asks}")
+            print(f"  bids: {top_bids}")
+        print()
+        await asyncio.sleep(5)
+
+
+# depth_cache_update_interval=500 → depth@500ms stream (recommended for Options)
+with BinanceLocalDepthCacheManager(exchange=exchange,
+                                   depth_cache_update_interval=500) as ubldc:
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\r\nGracefully stopping ...")
+    except Exception as e:
+        print(f"\r\nERROR: {e}")
+        print("Gracefully stopping ...")

--- a/examples/binance_options_depthcache/requirements.txt
+++ b/examples/binance_options_depthcache/requirements.txt
@@ -1,0 +1,1 @@
+unicorn-binance-local-depth-cache


### PR DESCRIPTION
## Summary
- New example under `examples/binance_options_depthcache/`
- Shows how to create and read local DepthCaches for Vanilla Options symbols
- Follows the same pattern as `binance_futures_depthcache`

## Test plan
- [x] Script structure matches existing examples