### PR TITLE
Default to depth@500ms for Options when no update_interval is set

### DIFF
--- a/unicorn_binance_local_depth_cache/manager.py
+++ b/unicorn_binance_local_depth_cache/manager.py
@@ -286,7 +286,11 @@ class BinanceLocalDepthCacheManager(threading.Thread):
         if isinstance(markets, str):
             markets = [markets, ]
         if self.depth_cache_update_interval is None:
-            channel = f"depth"
+            if self.exchange == "binance.com-vanilla-options" \
+                    or self.exchange == "binance.com-vanilla-options-testnet":
+                channel = "depth@500ms"
+            else:
+                channel = "depth"
         else:
             channel = f"depth@{self.depth_cache_update_interval}ms"
         for market in markets:


### PR DESCRIPTION
## Summary
- Options only supports `@depth@500ms` and `@depth@100ms` streams — bare `@depth` does not exist
- When `depth_cache_update_interval=None` (the default), Options now gets `depth@500ms` instead of the broken `depth`
- Spot/Futures behavior is unchanged (`depth` without interval)
- If the user explicitly sets an interval (e.g. `100`), it's used as-is

## Test plan
- [ ] `BinanceLocalDepthCacheManager(exchange="binance.com-vanilla-options")` works without explicit `depth_cache_update_interval`
- [ ] `BinanceLocalDepthCacheManager(exchange="binance.com", depth_cache_update_interval=None)` still uses `depth` (unchanged)