### PR TITLE
CHANGELOG: add Options default update interval fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/readme.html#installation-and-upgrade)
 
 ## 2.12.0.dev (development stage/unreleased/unstable)
+### Fixed
+- Options depth cache: default to `depth@500ms` when `depth_cache_update_interval` is not set (Options has no bare `@depth` stream)
 
 ## 2.12.0
 ### Added


### PR DESCRIPTION
Add missing CHANGELOG entry for the Options default `depth@500ms` fallback from PR #81.