### PR TITLE
Remove Gitter references

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -79,7 +79,6 @@ about:
     [![Read How To`s](https://img.shields.io/badge/read-%20howto-yellow)](https://technopathy.club)
     [![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache)
     [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
-    [![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-binance-suite/unicorn-binance-local-depth-cache?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
     [![Get Free Professional Support](https://img.shields.io/badge/chat-lucit%20support-004166)](https://www.lucit.tech/get-support.html)
 
     [![LUCIT-UBLDC-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/master/images/logo/LUCIT-UBLDC-Banner-Readme.png)](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache)
@@ -399,7 +398,6 @@ about:
 
     ## Social
     - [Discussions](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/discussions)
-    - [Gitter](https://gitter.im/unicorn-binance-suite/unicorn-binance-local-depth-cache)
     - [https://t.me/unicorndevs](https://t.me/unicorndevs)
     - [https://dev.binance.vision](https://dev.binance.vision)
     - [https://community.binance.org](https://community.binance.org)


### PR DESCRIPTION
## Summary
- Remove Gitter badge and Social section link from `meta.yaml` (Gitter service is dead)

## Test plan
- [ ] Verify no remaining Gitter references in `meta.yaml`
- [ ] Conda build still works with updated `meta.yaml`