### PR TITLE
llms.txt: add Version, Docs block and Related Modules

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -3,6 +3,8 @@
 > Synchronized local order books for Binance with real-time WebSocket updates.
 > Part of [UNICORN Binance Suite](https://github.com/oliver-zehentleitner/unicorn-binance-suite).
 
+Version: 2.12.x. Python 3.9 – 3.14.
+
 Install: `pip install unicorn-binance-local-depth-cache`
 Import: `from unicorn_binance_local_depth_cache import BinanceLocalDepthCacheManager, DepthCacheOutOfSync`
 
@@ -107,3 +109,18 @@ Returns: `list` of `[price, quantity]` pairs. Raises `DepthCacheOutOfSync` if ca
 - Do NOT poll `get_asks()`/`get_bids()` without sleep — the cache updates in real-time, you just read it
 - Use `with` context or call `ubldc.stop_manager()` to avoid orphaned threads
 - Market symbols are case-insensitive ("BTCUSDT" and "btcusdt" both work)
+
+## Related Modules
+
+- [UBWA](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api) — WebSocket engine UBLDC builds on. Stays hidden unless you want a shared instance.
+- [UBRA](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api) — REST client used internally for depth snapshots. Share via `ubra_manager=...`.
+- [UBDCC](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) — distributed, horizontally scalable cluster of UBLDC instances with load balancing, failover and REST API. Use UBLDC's `ubdcc_address=...` parameter to connect as a client.
+
+## Docs
+
+- Repo: https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache
+- Docs: https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/
+- Full manager reference: https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/unicorn_binance_local_depth_cache.html
+- PyPI: https://pypi.org/project/unicorn-binance-local-depth-cache/
+- conda-forge: https://anaconda.org/conda-forge/unicorn-binance-local-depth-cache
+- Changelog: https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/blob/master/CHANGELOG.md


### PR DESCRIPTION
Addresses the claude.ai review of the module llms.txt files.

- `Version: 2.12.x. Python 3.9 – 3.14.` under the blockquote.
- `## Docs` block at the bottom with Repo / Docs / full manager reference / PyPI / conda-forge / Changelog.
- `## Related Modules` pointing at UBWA (engine under the hood), UBRA (share via `ubra_manager=`) and UBDCC (connect as a client via `ubdcc_address=`).

No other changes — claude.ai flagged the existing structure (Quick Start with `DepthCacheOutOfSync`, Standalone vs. Cluster, `threshold_volume`) as exemplary, left it alone.