### PR TITLE
Clean remaining LUCIT references outside the conda pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 2.12.1.dev (development stage/unreleased/unstable)
 ### Changed
+- `setup.py`, `dev/set_version.py`, `dev/test_plain.py`: file header
+  `Author: LUCIT Systems and Development` → `Oliver Zehentleitner`,
+  copyright `LUCIT Systems and Development (2022-2023)` →
+  `Oliver Zehentleitner (2022-2026)`.
+- `dev/test_plain.py`: dropped the obsolete
+  `from lucit_licensing_python.exceptions import NoValidatedLucitLicense`
+  import and the corresponding `try/except NoValidatedLucitLicense`
+  wrapper — the LUCIT licensing manager has been removed from UBLDC.
+- `SECURITY.md`: replaced the lucit.tech contact form URL with the
+  GitHub Security Advisories private-reporting URL.
 - README: switched all conda references from the legacy `lucit` channel
   to `conda-forge`. Added conda-forge version / downloads / feedstock
   build badges. Removed the "There is no conda support until migration"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,12 +7,12 @@ This document outlines security procedures and general policies for the
   * [Comments on this Policy](#comments-on-this-policy)
 
 ## Reporting a Bug
-`LUCIT Systems and Development` takes all security bugs in `unicorn-binance-local-depth-cache` seriously.
+`Oliver Zehentleitner` takes all security bugs in `unicorn-binance-local-depth-cache` seriously.
 Thank you for improving the security of `unicorn-binance-local-depth-cache`. We appreciate your 
 efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 
-Report security bugs via our contact form: 
-https://www.lucit.tech/contact-unicorn-developers.html
+Please report security bugs privately via GitHub Security Advisories:
+https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/security/advisories/new
 
 The lead maintainer will acknowledge your email within 48 hours, and will send a
 more detailed response within 48 hours indicating the next steps in handling

--- a/dev/set_version.py
+++ b/dev/set_version.py
@@ -12,9 +12,9 @@
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/blob/master/LICENSE
 #
-# Author: LUCIT Systems and Development
+# Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 import sys

--- a/dev/test_plain.py
+++ b/dev/test_plain.py
@@ -12,17 +12,15 @@
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/blob/master/LICENSE
 #
-# Author: LUCIT Systems and Development
+# Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 from unicorn_binance_local_depth_cache import BinanceLocalDepthCacheManager, DepthCacheOutOfSync
-from lucit_licensing_python.exceptions import NoValidatedLucitLicense
 import asyncio
 import logging
 import os
-import sys
 
 logging.getLogger("unicorn_binance_local_depth_cache")
 logging.basicConfig(level=logging.DEBUG,
@@ -37,12 +35,8 @@ async def worker(ubldc):
     while ubldc.is_stop_request() is False:
         await asyncio.sleep(1)
 
-try:
-    with BinanceLocalDepthCacheManager(exchange="binance.com") as ubldc_manager:
-        try:
-            asyncio.run(worker(ubldc_manager))
-        except KeyboardInterrupt:
-            print("\r\nGracefully stopping ...")
-except NoValidatedLucitLicense as error_msg:
-    print(f"ERROR: {error_msg}")
-    sys.exit(1)
+with BinanceLocalDepthCacheManager(exchange="binance.com") as ubldc_manager:
+    try:
+        asyncio.run(worker(ubldc_manager))
+    except KeyboardInterrupt:
+        print("\r\nGracefully stopping ...")

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/blob/master/LICENSE
 #
-# Author: LUCIT Systems and Development
+# Author: Oliver Zehentleitner
 #
-# Copyright (c) 2022-2023, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2022-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
 from Cython.Build import cythonize


### PR DESCRIPTION
### Code + dev scripts
- `setup.py`, `dev/set_version.py`, `dev/test_plain.py`: file header `Author: LUCIT Systems and Development` → `Oliver Zehentleitner`; copyright `LUCIT Systems and Development (2022-2023)` → `Oliver Zehentleitner (2022-2026)`.
- `dev/test_plain.py`: dropped the obsolete `from lucit_licensing_python.exceptions import NoValidatedLucitLicense` import and the corresponding `try/except NoValidatedLucitLicense` wrapper — the LUCIT licensing manager has been gone from UBLDC for a while.

### Security policy
- `SECURITY.md`: replaced the lucit.tech contact form URL with the GitHub Security Advisories private-reporting URL.

Sphinx sources + historical CHANGELOG intentionally untouched.