### PR TITLE
Bump minimum unicorn-binance-websocket-api to 2.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 2.12.1.dev (development stage/unreleased/unstable)
 ### Changed
+- Bumped minimum `unicorn-binance-websocket-api` dependency from
+  `>=2.12.0` to `>=2.12.2` in `setup.py`, `requirements.txt`,
+  `pyproject.toml`, `environment.yml` and `meta.yaml`. 2.12.2 is the
+  cleanup-round UBWA release.
 - `setup.py`, `dev/set_version.py`, `dev/test_plain.py`: file header
   `Author: LUCIT Systems and Development` → `Oliver Zehentleitner`,
   copyright `LUCIT Systems and Development (2022-2023)` →

--- a/environment.yml
+++ b/environment.yml
@@ -10,4 +10,4 @@ dependencies:
   - orjson
   - requests>=2.32.3
   - unicorn-binance-rest-api>=2.10.0
-  - unicorn-binance-websocket-api>=2.12.0
+  - unicorn-binance-websocket-api>=2.12.2

--- a/meta.yaml
+++ b/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - orjson
     - requests >=2.32.3
     - unicorn-binance-rest-api >=2.10.0
-    - unicorn-binance-websocket-api >=2.12.0
+    - unicorn-binance-websocket-api >=2.12.2
   run:
     - python
     - aiohttp
@@ -35,7 +35,7 @@ requirements:
     - orjson
     - requests >=2.32.3
     - unicorn-binance-rest-api >=2.10.0
-    - unicorn-binance-websocket-api >=2.12.0
+    - unicorn-binance-websocket-api >=2.12.2
 
 test:
   imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ Cython = ">=3.0.10"
 orjson = "*"
 requests = ">=2.32.3"
 unicorn-binance-rest-api = ">=2.10.0"
-unicorn-binance-websocket-api = ">=2.12.0"
+unicorn-binance-websocket-api = ">=2.12.2"
 
 [tool.poetry.dev-dependencies]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ Cython>=3.0.10
 orjson
 requests>=2.32.3
 unicorn-binance-rest-api>=2.10.0
-unicorn-binance-websocket-api>=2.12.0
+unicorn-binance-websocket-api>=2.12.2

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
      long_description_content_type="text/markdown",
      license='MIT',
      install_requires=['aiohttp', 'Cython>=3.0.10', 'orjson', 'requests>=2.32.3',
-                       'unicorn-binance-websocket-api>=2.12.0', 'unicorn-binance-rest-api>=2.10.0'],
+                       'unicorn-binance-websocket-api>=2.12.2', 'unicorn-binance-rest-api>=2.10.0'],
      keywords='binance, depth cache',
      project_urls={
          'Documentation': 'https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache',


### PR DESCRIPTION
2.12.2 is the cleanup-round UBWA release. Bumping the constraint across all five dependency files (setup.py as source of truth).