### PR TITLE
Cross-link AGENTS.md and llms.txt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # AGENTS.md — UNICORN Binance Local Depth Cache
 
+> **End-user cheatsheet for AI-assisted consumption:** [`llms.txt`](llms.txt) — use that one if you're writing code *against* this library.
+> **This file** is for AI agents working *on* this repo itself.
+
 ## Planning & Backlog
 
 Open development tasks and decisions are tracked in **[TASKS.md](TASKS.md)**.

--- a/llms.txt
+++ b/llms.txt
@@ -119,6 +119,7 @@ Returns: `list` of `[price, quantity]` pairs. Raises `DepthCacheOutOfSync` if ca
 ## Docs
 
 - Repo: https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache
+- AGENTS.md (for AI agents working on this repo): https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/blob/master/AGENTS.md
 - Docs: https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/
 - Full manager reference: https://oliver-zehentleitner.github.io/unicorn-binance-local-depth-cache/unicorn_binance_local_depth_cache.html
 - PyPI: https://pypi.org/project/unicorn-binance-local-depth-cache/


### PR DESCRIPTION
Two AI-facing files, two audiences:

- `llms.txt` = cheat sheet for LLMs writing code **against** this library
- `AGENTS.md` = briefing for AI agents working **on** this repo

Adding explicit cross-links at the top of `AGENTS.md` and in the Docs block of `llms.txt` so either file points at the other.